### PR TITLE
Update to 0.4.5

### DIFF
--- a/urbit/Dockerfile
+++ b/urbit/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Paul Bellamy <paul.a.bellamy@gmail.com>
 RUN apt-get update \
  && apt-get install -y ca-certificates git wget
 
-RUN wget https://media.urbit.org/dist/debian/urbit_0.4.3-1_amd64.deb \
- && dpkg --force-depends -i urbit_0.4.3-1_amd64.deb \
+RUN wget https://media.urbit.org/dist/debian/urbit_0.4.5-1_amd64.deb \
+ && dpkg --force-depends -i urbit_0.4.5-1_amd64.deb \
  && apt-get install -fy
 
 WORKDIR /urbit


### PR DESCRIPTION
Fixes #2 

@s-ol, when building this for me, there was a complaint about:
```
dpkg: urbit: dependency problems, but configuring anyway as you requested:
 urbit depends on libgmp3-dev; however:
  Package libgmp3-dev is not installed.
 urbit depends on libsigsegv-dev; however:
  Package libsigsegv-dev is not installed.
 urbit depends on libcurl4-gnutls-dev; however:
  Package libcurl4-gnutls-dev is not installed.
```

Are you able to check it works for you before I push this?